### PR TITLE
Fix #10 RVE-2025-1 잠재적인 SQL 인젝션 이슈

### DIFF
--- a/classes/xml/xmlquery/argument/SortArgument.class.php
+++ b/classes/xml/xmlquery/argument/SortArgument.class.php
@@ -15,6 +15,43 @@ class SortArgument extends Argument
 		return $this->getUnescapedValue();
 	}
 
+	function ensureValidColumnName($default_value = NULL)
+	{
+		if(!isset($this->value) || $this->value === '')
+		{
+			return;
+		}
+
+		if($this->isValidColumnName($this->value))
+		{
+			return;
+		}
+
+		if(func_num_args() > 0)
+		{
+			$this->value = $default_value;
+			$this->uses_default_value = TRUE;
+			$this->isValid = TRUE;
+			$this->errorMessage = NULL;
+			return;
+		}
+
+		global $lang;
+		$key = $this->name;
+		$this->isValid = FALSE;
+		$this->errorMessage = new BaseObject(-1, sprintf($lang->filter->invalid, $lang->{$key} ? $lang->{$key} : $key));
+	}
+
+	function isValidColumnName($column_name)
+	{
+		if(!is_string($column_name))
+		{
+			return FALSE;
+		}
+
+		return preg_match('/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/', $column_name) === 1;
+	}
+
 }
 /* End of file SortArgument.class.php */
 /* Location: ./classes/xml/xmlquery/argument/SortArgument.class.php */

--- a/classes/xml/xmlquery/queryargument/SortQueryArgument.class.php
+++ b/classes/xml/xmlquery/queryargument/SortQueryArgument.class.php
@@ -20,6 +20,17 @@ class SortQueryArgument extends QueryArgument
 				, $this->argument_name
 				, $this->argument_name
 				, '$args->' . $this->variable_name);
+
+		$default_value = $this->argument_validator->getDefaultValueString();
+		if(isset($default_value))
+		{
+			$arg .= sprintf('${\'%s_argument\'}->ensureValidColumnName(%s);' . "\n", $this->argument_name, $default_value);
+		}
+		else
+		{
+			$arg .= sprintf('${\'%s_argument\'}->ensureValidColumnName();' . "\n", $this->argument_name);
+		}
+
 		$arg .= $this->argument_validator->toString();
 
 		$arg .= sprintf('if(!${\'%s_argument\'}->isValid()) return ${\'%s_argument\'}->getErrorMessage();' . "\n"

--- a/classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php
+++ b/classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php
@@ -80,6 +80,17 @@ class QueryArgumentValidator
 		return TRUE;
 	}
 
+	function getDefaultValueString()
+	{
+		if(!isset($this->default_value))
+		{
+			return NULL;
+		}
+
+		$default_value = new DefaultValue($this->argument_name, $this->default_value);
+		return $default_value->toString();
+	}
+
 	function toString()
 	{
 		$validator = '';


### PR DESCRIPTION
### Motivation

- Prevent SQL injection via XML query `navigation` where `index` var (e.g. `sort_index`) coming from request args could contain arbitrary SQL expressions. 
- Allow XML-hardcoded `default` expressions to remain usable while blocking user-supplied expressions.

### Description

- Added `ensureValidColumnName()` and `isValidColumnName()` to `SortArgument` so runtime sort arguments are accepted only when they match a plain column name or `table.column` identifier (file: `classes/xml/xmlquery/argument/SortArgument.class.php`).
- Updated `SortQueryArgument::toString()` to invoke `ensureValidColumnName()` and to fall back to the XML `<index default="...">` default when the supplied value is invalid (file: `classes/xml/xmlquery/queryargument/SortQueryArgument.class.php`).
- Added `QueryArgumentValidator::getDefaultValueString()` helper to produce the XML default value string for reuse by `SortQueryArgument` (file: `classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php`).
- When an invalid user-supplied `sort_index` is detected the code now replaces it with the XML default (if present) rather than allowing the raw expression to be passed through to the query builder.

### Testing

- Ran PHP syntax checks: `php -l classes/xml/xmlquery/argument/SortArgument.class.php`, `php -l classes/xml/xmlquery/queryargument/validator/QueryArgumentValidator.class.php`, and `php -l classes/xml/xmlquery/queryargument/SortQueryArgument.class.php` (all succeeded).
- Executed a small runtime check that validates a correct column name passes and an expression falls back to XML default using: `php -r 'require "classes/xml/xmlquery/argument/Argument.class.php"; require "classes/xml/xmlquery/argument/SortArgument.class.php"; $valid = new SortArgument("sort_index", "documents.list_order"); $valid->ensureValidColumnName(); if(!$valid->isValid() || $valid->getValue() !== "documents.list_order") { exit(1);} $fallback = new SortArgument("sort_index", "RAND()"); $fallback->ensureValidColumnName("list_order"); if(!$fallback->isValid() || $fallback->getValue() !== "list_order") { exit(2);} echo "ok";'` (returned `ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2d4c4afc832789b8c431c5a623a3)